### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/StreamTaskExecuteRunnable.java
+++ b/dolphinscheduler-master/src/main/java/org/apache/dolphinscheduler/server/master/runner/StreamTaskExecuteRunnable.java
@@ -392,7 +392,7 @@ public class StreamTaskExecuteRunnable implements Runnable {
                 Set<Integer> resourceIdsSet = resourceIdStream.collect(Collectors.toSet());
 
                 if (CollectionUtils.isNotEmpty(resourceIdsSet)) {
-                    Integer[] resourceIds = resourceIdsSet.toArray(new Integer[resourceIdsSet.size()]);
+                    Integer[] resourceIds = resourceIdsSet.toArray(new Integer[0]);
 
                     List<Resource> resources = processService.listResourceByIds(resourceIds);
                     resources.forEach(t -> resourcesMap.put(t.getFullName(),
@@ -494,7 +494,7 @@ public class StreamTaskExecuteRunnable implements Runnable {
     }
 
     private enum TaskRunnableStatus {
-        CREATED, STARTED,
+        CREATED, STARTED
         ;
     }
 }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:1788857452 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (1)
